### PR TITLE
Feature:plat 3163 - Autenticar en endpoint de controlador AbrahamHistoriesController

### DIFF
--- a/app/controllers/abraham_histories_controller.rb
+++ b/app/controllers/abraham_histories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AbrahamHistoriesController < ApplicationController
-  skip_authorization_check
+  load_and_authorize_resource
 
   def create
     @abraham_history = AbrahamHistory.new(abraham_history_params)


### PR DESCRIPTION
## Issues relacionados

[PLAT-3163](https://buk.atlassian.net/browse/PLAT-3163)

## Descripción del problema

### Contexto

Actualmente el controlador AbrahamHistoriesController se salta el proceso de autentificación, esto no es correcto ya que todo usuario que acceda a un Tour Guiado deberá estar previamente logeado

### Objetivo

No dejar abierto el controlador AbrahamHistoriesController

### Criterios de aceptación

* El endpoint solo será accesible por usuarios logeados en el sistema

## Qué se hizo para resolver problema

Actualmente ya tiene autenticación, porque tiene el `authenticity_token` que valida contra la sesión del usuario, entonces siempre va tener una sesión valida para funcionar el endpoint, sin embargo, agregamos el `load_and_authorize_resource` para permitir la autorización del usuario.

## Cómo Probar:

1. en el GemFile de Buk `packs/plataforma/Gemfile`
2. reemplazar `'abraham', path: '../../gems/abraham'`
3. por `gem 'abraham', git: 'https://github.com/bukhr/abraham.git', branch: 'feature/PLAT-3163-autenticar-endpoint-del-controlador-abraham-histories-controller'`
5. correr `bundle update abraham` y `bundle install --force`
6. Correr el proyecto y abrir el portal del colaborador
7. Abrir la herramienta de depuración de networking del Chrome
8. Revisar que el endpoint `/abraham_histories` no permite el acceso solamente con el `authenticity_token`. Es necesario agregar el `can [:create], AbrahamHistory` en el archivo `packs/plataforma/core_app/app/models/ability.rb` para permitir que el usuario tenga autorización para el action `:create`