### PR TITLE
Feature: Aagregando configuracion de render_partial personalizado

### DIFF
--- a/app/helpers/abraham_helper.rb
+++ b/app/helpers/abraham_helper.rb
@@ -15,6 +15,8 @@ module AbrahamHelper
     # Otherwise, default to the default locale
     tours ||= Rails.configuration.abraham.tours["#{controller_path}/#{action}/#{I18n.default_locale}"]
 
+    render_partial = Rails.configuration.abraham.render_partial || "application/abraham"
+
     if tours
       # Have any automatic tours been completed already?
       conditions = {
@@ -39,7 +41,7 @@ module AbrahamHelper
         flipper_activation = selected_tour["flipper_activation"]
 
         next unless should_add_tour(flipper_key, flipper_activation) && !tour_keys_completed.include?(key)
-        tour_html += render(partial: "application/abraham",
+        tour_html += render(partial: render_partial,
                             locals: { tour_name: key,
                                       tour_completed: tour_keys_completed.include?(key),
                                       trigger: selected_tour["trigger"],

--- a/app/views/application/_abraham.html.erb
+++ b/app/views/application/_abraham.html.erb
@@ -1,39 +1,23 @@
-<script nonce="<%= try(:content_security_policy_nonce) %>" id='tour-guiado'>
-  var screenWidth = window.innerWidth >= 960 ? 'desktop' : 'mobile';
+<script>
   Abraham.tours["<%= tour_name %>"] = new Shepherd.Tour(<%= Rails.configuration.abraham.tour_options.html_safe unless Rails.configuration.abraham.tour_options.nil? %>);
 
   <% if trigger != 'manual' %>
   Abraham.tours["<%= tour_name %>"].on("complete", function() {
-    <% if enable_amplitude %>
-      $(document).trigger('amplitudeTracking', {
-        message: 'End_Tour',
-        data: {
-          tour_name: `<%= tour_name %>`,
-        },
-      });
-    <% end %>
+    // Make AJAX call to save history of tour completion
     return fetch("/abraham_histories/", {
       method: "POST",
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         authenticity_token: '<%= form_authenticity_token %>',
         controller_name: '<%= controller_path %>',
-        action_name: '<%= action %>',
+        action_name: '<%= action_name %>',
         tour_name: '<%= tour_name %>'
       })
     });
   });
 
-  var setLater = () => {
-    Cookies.set('<%= abraham_cookie_prefix %>-<%= tour_name %>', 'later', { domain: '<%= abraham_domain %>',  expires: 15 });
-    Abraham.tours["<%= tour_name %>"].hide();
-  }
-
   Abraham.tours["<%= tour_name %>"].on("cancel", function() {
-    Abraham.tours["<%= tour_name %>"].complete();
-    <% if custom_function_on_cancel %>
-      <%= custom_function_on_cancel.html_safe %>
-    <% end %>
+    Cookies.set('<%= abraham_cookie_prefix %>-<%= tour_name %>', 'later', { domain: '<%= abraham_domain %>' });
   });
   <% end %>
 
@@ -41,80 +25,31 @@
   Abraham.tours["<%= tour_name %>"].addStep({
     id: 'step-<%= key %>',
     <% if step.key?('title') %>
-     title: `
-    <%= content_tag :div, class: step.key?('image_path') ? 'coachmark-image-container' : '' do %>
-      <% if step.key?('image_path') %>
-        <%= image_pack_tag step['image_path'], class: 'coachmark-image img-fluid' %>
-      <% end %>
-      <%= content_tag(:span, step['title'], class: 'coachmark-title-text') %>
-    <% end %>`,
-  <% end %>
-    text: `<%= sanitize step['text'] %>`,
+    title: "<%= step['title'] %>",
+    <% end %>
+    text: "<%= step['text'] %>",
     <% if step.key?('attachTo') %>
     attachTo: { element: "<%= escape_javascript(step['attachTo']['element'].html_safe) %>", on: "<%= step['attachTo']['placement'] %>" },
     showOn: function() {
+      // Only display this step if its selector is present
       return document.querySelector("<%= escape_javascript(step['attachTo']['element'].html_safe) %>") ? true : false
     },
-    <% end %>
-    <% if step.key?('floatingUIOptions') %>
-    floatingUIOptions: <%= step['floatingUIOptions'].html_safe %>,
-    <% end %>
-    <% if step.key?('modalOverlayOpeningPadding') %>
-    modalOverlayOpeningPadding: <%= step['modalOverlayOpeningPadding'] %>,
-    <% end %>
-    <% if step.key?('modalOverlayOpeningRadius') %>
-    modalOverlayOpeningRadius: <%= step['modalOverlayOpeningRadius'] %>,
-    <% end %>
-    <% if step.key?('beforeShowPromise') %>
-    beforeShowPromise(){<%= step['beforeShowPromise'].html_safe %>},
     <% end %>
     buttons: [
     <% if step.key?('buttons') %>
       <% step['buttons'].each do |button| %>
-        { text: `<%= button[1]['text'] %>`,
-          <% if button[1]['actionType'] == 'action' %>
-            action(){<%= button[1]['action'].html_safe %>},
-          <% else %>
-            <% if button[1]['action'] == 'next' && index == 0 %>
-              action() {
-                  <% if enable_amplitude %>
-                    $(document).trigger('amplitudeTracking', {
-                      message: 'Start_Tour',
-                      data: {
-                        tour_name: `<%= tour_name %>`,
-                      },
-                    });
-                  <% end %>
-                this.next()
-              },
-            <% else %>
-                action: Abraham.tours["<%= tour_name %>"].<%= button[1]['action'] %>,
-            <% end %>
-          <% end %>
-          classes: '<%= button[1]['classes'] %>' },
+        { text: '<%= button[1]['text']  %>', action: Abraham.tours["<%= tour_name %>"].<%= button[1]['action'] %>, classes: '<%= button[1]['classes'] %>' },
       <% end %>
     <% else %>
       <% if index == steps.size - 1 %>
-        { text: '<%= I18n.t('abraham.exit') %>', action: Abraham.tours["<%= tour_name %>"].complete, classes: 'btn-secondary' }
+        { text: '<%= t('abraham.done') %>', action: Abraham.tours["<%= tour_name %>"].complete }
       <% else %>
         <% if index == 0 %>
-          { text: '<%= I18n.t('abraham.next') %>',
-          action() {
-            <% if enable_amplitude %>
-              $(document).trigger('amplitudeTracking', {
-                message: 'Start_Tour',
-                data: {
-                  tour_name: `<%= tour_name %>`,
-                },
-              });
-            <% end %>
-           this.next()
-          },
-          classes: 'btn-secondary' },
-          { text: '<%= I18n.t('abraham.later') %>', action: setLater, classes: 'btn-primary ghost' }
+          { text: '<%= t('abraham.later') %>', action: Abraham.tours["<%= tour_name %>"].cancel, classes: 'shepherd-button-secondary' },
+          { text: '<%= t('abraham.continue') %>', action: Abraham.tours["<%= tour_name %>"].next }
         <% else %>
-        { text: '<%= I18n.t('abraham.next') %>', action: Abraham.tours["<%= tour_name %>"].next, classes: 'btn-secondary' },
-        { text: '<%= I18n.t('abraham.back') %>', action: Abraham.tours["<%= tour_name %>"].back, classes: 'btn-primary ghost' }
+        { text: '<%= t('abraham.exit') %>', action: Abraham.tours["<%= tour_name %>"].cancel, classes: 'shepherd-button-secondary' },
+        { text: '<%= t('abraham.next') %>', action: Abraham.tours["<%= tour_name %>"].next }
         <% end %>
       <% end %>
     <% end %>
@@ -131,28 +66,15 @@
         // Don't start the tour if the first step's element is missing
         tourMayStart = tourMayStart && document.querySelector("<%= steps.first[1]['attachTo']['element'] %>");
         <% end %>
-
-        if (tourMayStart && !Shepherd.activeTour) {
+        
+        if (tourMayStart) {
           start();
         }
       }
     }(Abraham.tours["<%= tour_name %>"].start)
 
     <% if !tour_completed %>
-      <% if display %>
-        if (screenWidth == '<%= display %>') {
-          Abraham.incompleteTours.push("<%= tour_name %>");
-          window.addEventListener('resize', () => {
-              let prevScreenWidth = screenWidth;
-              screenWidth = window.innerWidth >= 960 ? 'desktop' : 'mobile';
-              if(prevScreenWidth !== screenWidth) {
-                location.reload();
-              }
-          });
-        }
-      <% else %>
-        Abraham.incompleteTours.push("<%= tour_name %>");
-      <% end %>
+    Abraham.incompleteTours.push("<%= tour_name %>");
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## Descripción del problema

Actualmente el partial que estamos renderizando está en la gema, deberíamos permitir que el proyecto que utilice la gema defina que partial debe renderizar, teniendo en vista que hay muchas configuraciones involucradas en ese archivo.

## Qué se hizo para resolver problema
* Adicionamos  la variable `render_partial` a las configuraciones de Abraham (`Rails.configuration.abraham`), permitiendo que desde el inicializador se haga la configuración de que partial debe renderizar.

* Aplicamos el código original (de Abraham) del archivo `app/views/application/_abraham.html.erb`.